### PR TITLE
decode traces

### DIFF
--- a/cmd/tracedock/server/server.go
+++ b/cmd/tracedock/server/server.go
@@ -48,7 +48,7 @@ func execServerStartCmd(cmd *cobra.Command, args []string) {
 	orchestrator.Add(paramGRPCPort, grpcServer)
 	orchestrator.Add(paramHTTPPort, httpServer)
 
-	ingestor := func([]*trace.ResourceSpans) error {
+	ingestor := func(*trace.ResourceSpans) error {
 		return nil
 	}
 

--- a/cmd/tracedock/server/server.go
+++ b/cmd/tracedock/server/server.go
@@ -1,7 +1,8 @@
 package server
 
 import (
-	"fmt"
+	"log"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/tracedock/tracedock/internal/server"
@@ -55,12 +56,14 @@ func execServerStartCmd(cmd *cobra.Command, args []string) {
 	httpServer.RegisterTraceIngestor(ingestor)
 
 	if err := orchestrator.Run(); err != nil {
-		fmt.Printf("Error starting orchestrator: %v\n", err)
+		log.Printf("error starting orchestrator: %v", err)
 		return
 	}
 
+	time.Sleep(10 * time.Millisecond)
+
 	if err := orchestrator.Wait(); err != nil {
-		fmt.Printf("Error waiting for orchestrator: %v\n", err)
+		log.Printf("error waiting for orchestrator: %v", err)
 		return
 	}
 }

--- a/cmd/tracedock/server/server.go
+++ b/cmd/tracedock/server/server.go
@@ -48,7 +48,9 @@ func execServerStartCmd(cmd *cobra.Command, args []string) {
 	orchestrator.Add(paramGRPCPort, grpcServer)
 	orchestrator.Add(paramHTTPPort, httpServer)
 
-	ingestor := func(*trace.ResourceSpans) error {
+	ingestor := func(resource *trace.ResourceSpans) error {
+		log.Printf("hello from processor %#v", resource)
+
 		return nil
 	}
 

--- a/cmd/tracedock/server/server.go
+++ b/cmd/tracedock/server/server.go
@@ -49,7 +49,7 @@ func execServerStartCmd(cmd *cobra.Command, args []string) {
 	orchestrator.Add(paramHTTPPort, httpServer)
 
 	ingestor := func(resource *trace.ResourceSpans) error {
-		log.Printf("hello from processor %#v", resource)
+		log.Printf("received a resource with %d attributes", len(resource.Resource.Attributes))
 
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.7.1
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.7
+	go.uber.org/zap v1.27.0
 )
 
 require (
@@ -17,6 +18,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
 golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -46,7 +46,7 @@ func (s *GRPCServer) Export(ctx context.Context, req *tracecollectorv1.ExportTra
 	}
 
 	for _, resource := range req.GetResourceSpans() {
-		if thisErr := s.traceIngestor(resource); err != nil {
+		if thisErr := s.traceIngestor(resource); thisErr != nil {
 			err = errors.Join(err, thisErr)
 		}
 	}

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -12,6 +12,13 @@ import (
 )
 
 // GRPCServer implements Server interface for the gRPC protocol
+//
+// Notice: It isn't implementing 100% of the OpenTelemetry HTTP specification
+// regarding to the responses content.
+//
+// This behaviour wasn't tested yet.
+//
+// For more details: https://opentelemetry.io/docs/specs/otlp/#otlpgrpc-response
 type GRPCServer struct {
 	server        *grpc.Server
 	traceIngestor TraceIngestor

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"log"
 	"net"
 
 	"google.golang.org/grpc"
@@ -46,6 +47,8 @@ func (s *GRPCServer) Export(ctx context.Context, req *tracecollectorv1.ExportTra
 
 // Start the gRPC server
 func (s *GRPCServer) Start(addr string) error {
+	log.Printf("starting gRPC server at %s", addr)
+
 	if s.traceIngestor == nil {
 		return ErrNoIngestorRegistered
 	}

--- a/internal/server/grpc_test.go
+++ b/internal/server/grpc_test.go
@@ -17,7 +17,7 @@ func TestNewGRPCServer(t *testing.T) {
 	assert.NotNil(t, server.server)
 }
 
-func TestGRPCServer_Start(t *testing.T) {
+func Test_GRPCServer_Start(t *testing.T) {
 	t.Run("should return error when no ingestor is registered", func(t *testing.T) {
 		server := NewGRPCServer()
 		err := server.Start(":8080")
@@ -51,7 +51,7 @@ func TestGRPCServer_Start(t *testing.T) {
 	})
 }
 
-func TestGRPCServer_Export(t *testing.T) {
+func Test_GRPCServer_Export(t *testing.T) {
 	t.Run("should return error when no ingestor is registered", func(t *testing.T) {
 		server := NewGRPCServer()
 

--- a/internal/server/grpc_test.go
+++ b/internal/server/grpc_test.go
@@ -30,7 +30,7 @@ func TestGRPCServer_Start(t *testing.T) {
 		var addr = "0.0.0.0:8081"
 		var done = make(chan error)
 
-		var ingestor = func([]*trace.ResourceSpans) error { return nil }
+		var ingestor = func(*trace.ResourceSpans) error { return nil }
 
 		server := NewGRPCServer()
 		server.RegisterTraceIngestor(ingestor)
@@ -68,8 +68,8 @@ func TestGRPCServer_Export(t *testing.T) {
 	t.Run("should process traces successfully", func(t *testing.T) {
 		var processedTraces []*trace.ResourceSpans
 
-		ingestor := func(resource []*trace.ResourceSpans) error {
-			processedTraces = append(processedTraces, resource...)
+		ingestor := func(resource *trace.ResourceSpans) error {
+			processedTraces = append(processedTraces, resource)
 			return nil
 		}
 
@@ -91,7 +91,7 @@ func TestGRPCServer_Export(t *testing.T) {
 	})
 
 	t.Run("should return error when ingestor fails", func(t *testing.T) {
-		ingestor := func(resource []*trace.ResourceSpans) error {
+		ingestor := func(resource *trace.ResourceSpans) error {
 			return assert.AnError
 		}
 

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -58,6 +58,10 @@ func (s *HTTPServer) Start(addr string) error {
 
 // Stop the HTTP server
 func (s *HTTPServer) Stop() error {
+	if s.httpServer == nil {
+		return nil
+	}
+
 	background := context.Background()
 	ctx, cancel := context.WithTimeout(background, 5*time.Second)
 

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"regexp"
 	"time"
@@ -20,6 +21,8 @@ func NewHTTPServer() *HTTPServer {
 
 // Start the HTTP server
 func (s *HTTPServer) Start(addr string) error {
+	log.Printf("starting HTTP server at %s", addr)
+
 	if s.traceIngestor == nil {
 		return ErrNoIngestorRegistered
 	}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -17,6 +17,15 @@ import (
 )
 
 // HTTPServer implements Server interface for the HTTP protocol
+//
+// Notice: It isn't implementing 100% of the OpenTelemetry HTTP specification
+// regarding to the responses bodies, instead, for now it only respond with
+// correct status code without any response bodies.
+//
+// This behaviour was tested with Ruby and Python OpenTelemetry SDKs and worked
+// with no issues.
+//
+// For more details: https://opentelemetry.io/docs/specs/otlp/#otlphttp-response
 type HTTPServer struct {
 	httpServer    *http.Server
 	traceIngestor TraceIngestor

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -21,7 +21,7 @@ func Test_HTTPServer_Start(t *testing.T) {
 	t.Run("should return error when server fails to start", func(t *testing.T) {
 		var addr = "0.0.0.0:8080"
 
-		var ingestor = func(traces []*trace.ResourceSpans) error {
+		var ingestor = func(traces *trace.ResourceSpans) error {
 			return nil
 		}
 
@@ -41,7 +41,7 @@ func Test_HTTPServer_Start(t *testing.T) {
 
 		var done = make(chan error)
 
-		var ingestor = func([]*trace.ResourceSpans) error {
+		var ingestor = func(*trace.ResourceSpans) error {
 			return nil
 		}
 
@@ -103,7 +103,9 @@ func Test_HTTPServer_HandleRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			server := NewHTTPServer()
 
-			server.RegisterTraceIngestor(func([]*trace.ResourceSpans) error { return nil })
+			server.RegisterTraceIngestor(func(*trace.ResourceSpans) error {
+				return nil
+			})
 
 			req := httptest.NewRequest(tc.method, tc.urlPath, nil)
 			req.Header.Set("Content-Type", tc.contentType)

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -10,23 +10,30 @@ import (
 	trace "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
+var addr string = "0.0.0.0:8080"
+
+var ingestor = func(traces *trace.ResourceSpans) error {
+	return nil
+}
+
 func Test_HTTPServer_Start(t *testing.T) {
 	t.Run("should return error when no ingestor is registered", func(t *testing.T) {
-		err := NewHTTPServer().Start(":8080")
+		server := NewHTTPServer()
 
-		assert.Error(t, err)
-		assert.Equal(t, ErrNoIngestorRegistered, err)
+		t.Cleanup(func() {
+			server.Stop()
+		})
+
+		assert.Equal(t, ErrNoIngestorRegistered, server.Start(addr))
 	})
 
 	t.Run("should return error when server fails to start", func(t *testing.T) {
-		var addr = "0.0.0.0:8080"
-
-		var ingestor = func(traces *trace.ResourceSpans) error {
-			return nil
-		}
-
 		server := NewHTTPServer()
 		server.RegisterTraceIngestor(ingestor)
+
+		t.Cleanup(func() {
+			server.Stop()
+		})
 
 		go func() { server.Start(addr) }()
 
@@ -37,16 +44,15 @@ func Test_HTTPServer_Start(t *testing.T) {
 	})
 
 	t.Run("should start server successfully when ingestor is registered", func(t *testing.T) {
-		var addr = "0.0.0.0:8080"
-
 		var done = make(chan error)
-
-		var ingestor = func(*trace.ResourceSpans) error {
-			return nil
-		}
+		var addr string = "0.0.0.0:0"
 
 		server := NewHTTPServer()
 		server.RegisterTraceIngestor(ingestor)
+
+		t.Cleanup(func() {
+			server.Stop()
+		})
 
 		go func() {
 			time.Sleep(100 * time.Millisecond)
@@ -61,7 +67,7 @@ func Test_HTTPServer_Start(t *testing.T) {
 			// failed to start so it should fail anyway
 			assert.NoError(t, err)
 
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(150 * time.Millisecond):
 			server.Stop()
 			assert.Equal(t, addr, server.httpServer.Addr)
 		}

--- a/internal/server/orchestrator.go
+++ b/internal/server/orchestrator.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -71,6 +72,8 @@ func (o *Orchestrator) Run() error {
 
 // Wait blocks until an interrupt signal is received and stops all servers
 func (o *Orchestrator) Wait() error {
+	log.Print("application is running, try CTRL+C to stop")
+
 	var sigChan = make(chan os.Signal, 1)
 
 	if o.state != Running {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,7 +13,7 @@ var (
 )
 
 // TraceIngestor is the function signature for processing trace data
-type TraceIngestor func([]*trace.ResourceSpans) error
+type TraceIngestor func(*trace.ResourceSpans) error
 
 // Server defines the interface for the trace server
 type Server interface {


### PR DESCRIPTION
Enables tracedock to receive OpenTelemetry requests from SDK, decode and call a ingestor function that will be implemented futurelly.

Part of #1 and #2 